### PR TITLE
Moved chapter ordering into a book.yml file

### DIFF
--- a/content/_ext/handbook.rb
+++ b/content/_ext/handbook.rb
@@ -22,7 +22,7 @@ module Awestruct
 
       def initialize(book_dir)
         @book_dir = book_dir
-        @chapters = {}
+        @chapters = []
       end
 
       def chapter_for_path(path)
@@ -46,19 +46,28 @@ module Awestruct
         # We need a map of source files to their Awestruct::Page to avoid
         # re-rendering things too much in the process of generating this page
         pagemap = site.pages.map { |p| [p.source_path, p] }.to_h
-        chapters = Dir[File.join(@book_dir, "/**/chapter.yml")]
+        book_file = File.join(@book_dir, "book.yml")
 
-        chapters.map { |c| [c, YAML.load(File.read(c))] }.each do |file, yaml|
-          dir = File.dirname(file)
+        book_yaml = YAML.load(File.read(book_file))
+
+        chapters = book_yaml['chapters']
+
+        chapters.each do |c|
+          dir = File.join(@book_dir, c)
+          file = File.join(dir, 'chapter.yml')
           overview = File.join(dir, 'index.adoc')
-          # Without an overview page, there's no point in attempting to add
+
+          # Without an chapter file and overview page, there's no point in attempting to add
           # this to the structure
+          next unless File.exists? file
           next unless File.exists? overview
 
+          yaml = YAML.load(File.read(file))
+
           chapter = Chapter.new
-          chapter.number = yaml['chapter']
+          chapter.key = c
+          chapter.full_path = dir
           chapter.title = pagemap[overview].title
-          chapter.key = File.basename(dir)
 
           if sections = yaml['sections']
             sections.each do |s|
@@ -70,7 +79,7 @@ module Awestruct
             end
           end
 
-          site.handbook.chapters[chapter.number] = chapter
+          site.handbook.chapters << chapter
         end
       end
     end

--- a/content/_layouts/chapter.html.haml
+++ b/content/_layouts/chapter.html.haml
@@ -9,20 +9,17 @@ layout: default
 
     = content
 
-    - chapter_key = File.basename(File.dirname(page.source_path))
-    - chapter = site.handbook.chapter_for_path(chapter_key)
+    - site.handbook.chapters.each do |chapter|
+      - if chapter.sections && chapter.sections.size > 0
+        %h2
+          Sub-sections
 
-    - if chapter.sections && chapter.sections.size > 0
-      %h2
-        Sub-sections
-
-      %ul
-        - chapter.sections.each do |section|
-          %li
-            %a{:href => section.key}
-              = section.title
+        %ul
+          - chapter.sections.each do |section|
+            %li
+              %a{:href => section.key}
+                = section.title
 
     .section_nav.page-link
       %a{:href => '..'}
         Index
-

--- a/content/_layouts/section.html.haml
+++ b/content/_layouts/section.html.haml
@@ -5,7 +5,7 @@ layout: default
 :ruby
   section_key = File.basename(page.source_path, File.extname(page.source_path))
   chapter_key = File.basename(File.dirname(page.source_path))
-  chapter = site.handbook.chapter_for_path(chapter_key)
+  chapter = site.handbook.chapters.find { |c| c.key == chapter_key }
 
   our_index = chapter.sections.find_index { |s| s.key == section_key }
   total = chapter.sections.size

--- a/content/doc/book/appendix/chapter.yml
+++ b/content/doc/book/appendix/chapter.yml
@@ -1,4 +1,3 @@
 ---
-chapter: 100
 sections:
   - installing

--- a/content/doc/book/best-practices/chapter.yml
+++ b/content/doc/book/best-practices/chapter.yml
@@ -1,3 +1,2 @@
 ---
-chapter: 4
 sections:

--- a/content/doc/book/book.yml
+++ b/content/doc/book/book.yml
@@ -1,0 +1,12 @@
+---
+chapters:
+  - getting-started
+  - using
+  - managing
+  - best-practices
+  - pipeline
+  - use-case
+  - operating
+  - scaling
+  - contributing
+  - appendix

--- a/content/doc/book/contributing/chapter.yml
+++ b/content/doc/book/contributing/chapter.yml
@@ -1,3 +1,2 @@
 ---
-chapter: 9
 sections:

--- a/content/doc/book/getting-started/chapter.yml
+++ b/content/doc/book/getting-started/chapter.yml
@@ -1,4 +1,3 @@
 ---
-chapter: 1
 sections:
   - installing

--- a/content/doc/book/index.html.haml
+++ b/content/doc/book/index.html.haml
@@ -5,8 +5,7 @@ title: "Jenkins Handbook"
 
 
 %ol
-  - site.handbook.chapters.keys.sort.each do |c|
-    - chapter = site.handbook.chapters[c]
+  - site.handbook.chapters.each do |chapter|
     %li
       %a{:href => chapter.key}
         %h4

--- a/content/doc/book/managing/chapter.yml
+++ b/content/doc/book/managing/chapter.yml
@@ -1,5 +1,4 @@
 ---
-chapter: 3
 sections:
   - plugins
   - system-configuration

--- a/content/doc/book/operating/chapter.yml
+++ b/content/doc/book/operating/chapter.yml
@@ -1,5 +1,4 @@
 ---
-chapter: 7
 sections:
   - backing-up
   - monitoring

--- a/content/doc/book/pipeline/chapter.yml
+++ b/content/doc/book/pipeline/chapter.yml
@@ -1,5 +1,4 @@
 ---
-chapter: 5
 sections:
   - overview
   - jenkinsfile

--- a/content/doc/book/use-case/chapter.yml
+++ b/content/doc/book/use-case/chapter.yml
@@ -1,5 +1,4 @@
 ---
-chapter: 6
 sections:
   - dotnet
   - java

--- a/content/doc/book/using/chapter.yml
+++ b/content/doc/book/using/chapter.yml
@@ -1,3 +1,2 @@
 ---
-chapter: 2
 sections:

--- a/content/doc/index.html.haml
+++ b/content/doc/index.html.haml
@@ -44,8 +44,7 @@ section: doc
     Chapters
   %div
     %ol
-      - site.handbook.chapters.keys.sort.each do |c|
-        - chapter = site.handbook.chapters[c]
+      - site.handbook.chapters.each do |chapter|
         %li
           %a{:href => File.join('book', chapter.key)}
             = chapter.title
@@ -70,7 +69,7 @@ section: doc
 
   %p
     For developers wishing to hack on, or extend Jenkins we have a number of
-    documentation resources available. The 
+    documentation resources available. The
     %a{:href => 'https://wiki.jenkins-ci.org/display/JENKINS/Extend+Jenkins'}
       %strong
         Extend Jenkins
@@ -96,4 +95,3 @@ section: doc
         %li
           %a{:href => "http://javadoc.jenkins.io/archive/jenkins-#{version}"}
             = version
-


### PR DESCRIPTION
@rtyler 
Not to call your baby ugly, but I'd like to move the ordering of the chapters into a single file. 

On one hand, it make a hot file for any time we move chapters around. On the other hand, it is nice to humans who want to be able to see the order of the chapters.  The old way also involved potentially changing multiple files just to change the order of one chapter.   
